### PR TITLE
fix setting name detect_anomalies.sql

### DIFF
--- a/macros/detect_anomalies.sql
+++ b/macros/detect_anomalies.sql
@@ -1,7 +1,7 @@
 {% macro detect_anomalies(relation, source, threshold = 0.95) %}
     ml.detect_anomalies(
         model {{ relation }},
-        struct({{ threshold }} as anomaly_prob_threshold),
+        struct({{ threshold }} as contamination),
         (select * from {{ source }})
     )
 {% endmacro %}


### PR DESCRIPTION
fix for

```
Database Error
Invalid table-valued function ml.detect_anomalies detect_anomalies settings for 'anomaly_prob_threshold' only applies to model type ARIMA_PLUS or ARIMA_PLUS_XREG but got KMEANS. at [15:5]
```